### PR TITLE
add edit link to github in page footer template

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -47,3 +47,4 @@ theme = 'gokarna'
   description = "International Research Network"
   footer = 'Research Network for Digital Old Norse Studies.'
   github = 'https://github.com/network-digital-old-norse-studies'
+  repo = 'https://github.com/network-digital-old-norse-studies/network-digital-old-norse-studies.github.io'

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,8 +1,16 @@
 <footer class="footer">
+    {{ $githubUrl := printf "%s/tree/main/content/%s" $.Site.Params.Repo (replace .File.Path "\\" "/") }}
     <span>&copy; {{ now.Year }} {{ .Site.Params.Footer}}</span>
     <span>Visit us at <a target="_blank" href="{{ .Site.Params.Github }}">GitHub</a>.</span>
     <span>
         Created with <a target="_blank" href="https://gohugo.io/">Hugo</a> using the
         <a target="_blank" href="https://github.com/526avijitgupta/gokarna">Gokarna</a> theme.
     </span>
+    <p>
+        <span>
+            <a target="_blank" href="{{ $githubUrl }}">
+                <span data-feather='edit'></span> improve this page here.
+            </a>
+        </span>
+    </p>
 </footer>


### PR DESCRIPTION
I was fiddling around with the page templates a bit. Added a link to the github repo which (most of the time) brings you to the correct file:

![image](https://user-images.githubusercontent.com/33053745/207582019-9121896e-0543-41e6-adea-6ea9639e8408.png)

(it's red because I'm mouse hovering it, so it displays where the link leads to)