### PR TITLE
Update home page content, simplify footer, fill in post content

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -19,7 +19,7 @@ network members.
 
 ---
 
-## Current
+## Current Activities
 
 In 2026, we are holding a monthly informal "coffee meeting" — a short online get-together for network members to share
 updates and chat about their current projects or exciting new trends in the field. Everyone is welcome to drop in.

--- a/content/posts/annual board meeting 2023.md
+++ b/content/posts/annual board meeting 2023.md
@@ -12,17 +12,17 @@ The Zoomlink will be sent out beforehand.
 
 # Agenda
 
-1.	Welcome
-2.	Deciding on a minute taker
-3.	Agenda and potential addenda
-4.	Year in Review: Activities 2023
-5.	Quo vadis, Network?
+1. Welcome
+2. Deciding on a minute taker
+3. Agenda and potential addenda
+4. Year in Review: Activities 2023
+5. Quo vadis, Network?
     1. How open or closed do we want the network to be?
-    2.	Frequency of Meetings, Possibility of Meeting in Person
-    3.	What Do We Want and/or Need from this Network?
-    4.	Ideas for Workshops, Events, Seminars
-6.	Tasks and Responsibilities
-7.	Misc
+    2. Frequency of Meetings, Possibility of Meeting in Person
+    3. What Do We Want and/or Need from this Network?
+    4. Ideas for Workshops, Events, Seminars
+6. Tasks and Responsibilities
+7. Misc
 
 # Minutes
 

--- a/content/posts/annual board meeting 2024.md
+++ b/content/posts/annual board meeting 2024.md
@@ -12,20 +12,81 @@ The Zoomlink will be sent out beforehand.
 
 # Agenda
 
-1.	Welcome
-2.	Deciding on a minute taker
-3.	Agenda and potential addenda
-4.	Year in Review: Activities 2024
-5.	Quo vadis, Network?
+1. Welcome
+2. Deciding on a minute taker
+3. Agenda and potential addenda
+4. Year in Review: Activities 2024
+5. Quo vadis, Network?
     1. How open or closed do we want the network to be?
-    2.	Frequency of Meetings, Possibility of Meeting in Person
-    3.	What Do We Want and/or Need from this Network?
-6.	Workshops, Events, Seminars
+    2. Frequency of Meetings, Possibility of Meeting in Person
+    3. What Do We Want and/or Need from this Network?
+6. Workshops, Events, Seminars
     1. Planned and upcoming
     2. Ideas for future events
-7.	Tasks and Responsibilities
-8.	Misc
+7. Tasks and Responsibilities
+8. Misc
 
 # Minutes
 
-The minutes will be added after the meeting has concluded.
+Attendants: Balduin Landolt, Beeke Stegmann, Eline Elmiger, Guðrún Laufey Guðmundsdóttir, Madita Knöpfle (Chair), Sven Kraus (Presiding), William Duba (Minutes)
+
+## 1. Welcome
+
+The meeting began at 11:02 AM, Central European Time. Sven is moderating.
+
+## 2. Deciding on a minute taker
+
+William Duba will be taking the minutes.
+
+## 3. Agenda and potential addenda
+
+Additional items were added to Miscellaneous: Website/GitHub, external communication, and Python Menota Parser.
+
+## 4. Year in Review: Activities 2024
+
+Compared to 2023, 2024 was a relatively low-key year. The Network held two workshops, coordinated by Balduin and Sven, on RDF and Graph Databases. A couple of informal online coffee chats were held. The mailing list remains an opportunity for messaging members of the group.
+
+## 5. Quo vadis, Network?
+
+### 1. How open or closed do we want the network to be?
+
+In general and in relation to a query from Tarrin relaying one of a doctoral student, discussion addressed how open the Network should be. The general consensus was that the Network should be open to new members, although the issue was raised of how to introduce prospective members to the network. Inviting people to workshops and meetings was suggested, as well as including people on the mailing list.
+
+Another question involved the level of engagement required for membership. Should dormant members be contacted to see if they have an interest in continuing? Related to this is that the biographies on the about page should be updated, and members are encouraged to go there and keep their information current.
+
+### 2. Frequency of Meetings, Possibility of Meeting in Person
+
+The value of regular 30-minute "coffee meetings", where members informally talk about their research, was repeatedly underscored. An in-person meeting would be desirable, and members are encouraged to seek out funding sources to make this possible.
+
+### 3. What Do We Want and/or Need from this Network?
+
+Beeke raised the topic of the Network's connection to Menota. With retirement, Menota has been in a transition phase, but the value of the resource to the community, not just as an archive, but as a platform with a handbook and tools of broader application. While it will persist as an archive with XML-encoded data, it will hopefully become more open in the future. The possibilities of aligning the Network with some of the actions to advance Menota were discussed, including a possible Network workshop on Menota.
+
+## 6. Workshops, Events, Seminars
+
+### 1. Planned and upcoming
+
+On 7 February, Juliane has organized a workshop on Digital Paleography with Peter Stokes.
+
+At the Saga Conference in August, the Network will have a Round Table featuring many members. Sven will be contacting those participants in mid-February.
+
+### 2. Ideas for future events
+
+Sven raised the question about the Manuscript Summer School, which will be in Copenhagen, starting around 10 August, and the possibility of having some input with regards to Digital Codicology/Paleography/Tools.
+
+Madita and Sven will investigate setting up a workshop on MUFI/Runicode and the "Stroke Selector" (https://mufi.info/q.php?p=mufi/runic/strokeselect).
+
+Sven drew attention to the Call for Papers for the 4th IEEE Conference on Digital Preservation and Processing Technologies of Written Heritage and expressed the desire that medievalists be represented there.
+
+## 7. Tasks and Responsibilities
+
+Madita gracefully accepted to continue serving as chair of the Network. Given the absence of Tarrin and Svenja, the coordination of workshops was deferred to the February workshop.
+
+## 8. Miscellaneous
+
+- GitHub: if pull requests are not being tended to, or otherwise updates are needed, members are invited to send Balduin or Sven an email.
+- External communication: currently, the website is considered the primary means of external communications.
+- Python Parser: Sven has developed a Python parser for Menota, that processes the XML and returns a class entity. It is approaching v0.1 status.
+- News from Fribourg: William is organizing Swiss guidelines for photographing manuscripts. E-codices will need a new version, and he is looking for anyone interested in discussing what they'd like from a digital manuscript library.
+
+The meeting ended around 12:23 Central European Time.

--- a/content/posts/annual-board-meeting-2025.md
+++ b/content/posts/annual-board-meeting-2025.md
@@ -1,8 +1,118 @@
 ---
 title: "Annual Board Meeting 2025"
-date: 2025-12-09T11:00:00+01:00
+date: 2025-12-09T16:00:00+01:00
 description: "We will get together to look back on 2025 and make plans for 2026."
 type: "post"
 ---
 
-TODO: Add description of the board meeting.
+# Date and Time
+
+The Board Meeting will be held on Zoom on December 9 at 4 pm CET.
+
+# Agenda
+
+1. Welcome
+2. Deciding on a minute taker
+3. Minutes last Annual Board Meeting
+4. Agenda and potential addenda
+5. Year in Review: Activities 2025
+    1. Workshop with Peter Stokes
+    2. Saga Conference
+6. Quo vadis, Network?
+    1. Frequency of Meetings, Possibility of Meeting in Person
+    2. What Do We Want and/or Need from this Network?
+7. Workshops, Events, Seminars: Plans? Wishes?
+8. Tasks and Responsibilities
+9. Misc
+
+# Minutes
+
+Attendants: Madita Knöpfle, Eline Elmiger, William Duba, Tarrin Wills, Beeke Stegmann, Guðrún Laufey Guðmundsdóttir, Nora Kauffeldt, Juliane Tiemann, Svenja Walkenhorst, Balduin Landolt
+
+## 1. Welcome
+
+Madita Knöpfle opens the Annual Board Meeting and welcomes all participants.
+
+## 2. Deciding on a minute taker
+
+Eline Elmiger volunteers to take the minutes.
+
+## 3. Minutes last Annual Board Meeting
+
+Minutes of the 2024 board meeting are approved, the group thanks William for last year's minutes.
+
+## 4. Agenda and potential addenda
+
+No additions were proposed.
+
+## 5. Year in Review: Activities 2025
+
+Madita informs the group that Sven has left academia and thereby the network.
+
+### 1. Workshop with Peter Stokes
+
+Balduin: Very interesting, would have wished for a larger audience; timely topic (AI); interesting discussions. Especially the idea of using generative AI to create synthetic manuscript data for training models has been shown to work well in practice. But Peter talked also about a broader range of use for AI, machine learning and manuscripts.
+
+Tarrin: Found the workshop highly interesting.
+
+### 2. Saga Conference
+
+Tarrin: Session well attended, interesting discussions; fulfilled its purpose of showcasing digital approaches to non-DH scholars, but the focus was not always where we wanted it to be.
+
+Beeke: Very positive feedback; reached many people who were impressed and interested, we covered a lot.
+
+Guðrún Laufey: Asked if interested audience members had reached out; QR code was provided, but no one has reached out yet. It was good that the round table went from basic to very specific.
+
+## 6. Quo vadis, Network?
+
+Both points (frequency of meetings and what do we want/need from the network) were discussed together.
+
+Beeke informs the group about a new Digital Network Center in Iceland, who have almost weekly or bi-weekly talks, usually online:
+
+- https://mshl.is/
+- https://www.youtube.com/@MSHLIceland
+
+Interest in future talks from:
+
+- Cassidy Croci (network analysis)
+- Trausti (Handritaskuggsjá; harvesting data from handrit.is: https://skuggsja.arnastofnun.is/)
+- Manuscripta.se team (Alexandra Petrulevich, Patrik Granholm)
+- Swedish manuscript initiatives, as Sweden is currently underrepresented in the network.
+
+Discussion of machine learning, HTR, and statistical methods. Critical reflections on LLMs and the "black box" problem. Interest in locally trained or institutional LLMs.
+
+Members reaffirm interest in continuing the network. Balduin: Limited time but wishes for more regular meetings; someone should coordinate. Svenja: Volunteers to initiate regular meetings; has more capacity next year. Tarrin: Would appreciate informal monthly coffee meetings to share experiences and examples; more formal events can be organised by the members that are interested. Juliane: Supports regular meetings (monthly or bimonthly) and proposes an automated calendar series.
+
+Regarding meeting in person: general agreement to revisit the question once capacity and funding are clearer. Members should inquire about funding possibilities at their universities.
+
+## 7. Workshops, Events, Seminars
+
+William reports on upcoming events:
+
+- 3-4 February (Fribourg): Linking data & digitization in medieval manuscripts (with Digital Scriptorium, e-codices NL etc.).
+- 1-3 July: Fragmentarium collaboration with Canada on developing methodology for working with liturgical fragments.
+- Summer schools with Peter Fornaro and Tobias Hodel.
+- Second week of September: Doctoral school in digital methods.
+
+Beeke: Notes upcoming event: Menota (and MUFI) 25-year anniversary in Reykjavík on 10 September 2026, could maybe organize something for network members.
+
+Svenja: Handschriftencensus will look at German manuscripts in Scandinavia and might do an event (possibly in Bergen). Historikertag will have a group focusing on digital methods (sometime in September 2026).
+
+## 8. Tasks and Responsibilities
+
+1. AG "meeting-in-person" (find out: who is interested, who has funding, who wants to organise): Nora
+2. Monthly meet-up: Svenja
+3. Menota: Beeke
+4. Swedish digital infrastructure: Guðrún Laufey (update later in 2026)
+5. Codicum: Juliane
+6. Leeds 2027: Svenja
+7. Chair (annual board meeting): Madita
+8. Website: Balduin, Eline (reviewer)
+9. Mailing list: Eline, Balduin
+10. Talk on Handritaskuggsjá by Trausti: Beeke
+
+## 9. Miscellaneous
+
+Nora notes that the Saga Conference round table will feature in the NOFO conference report. Svenja will send a Nuudle for a regular coffee meeting time slot.
+
+Madita closes the meeting and thanks all participants.

--- a/content/posts/coffee-meeting-2026-03.md
+++ b/content/posts/coffee-meeting-2026-03.md
@@ -5,4 +5,6 @@ description: "Informal monthly coffee meeting"
 type: "post"
 ---
 
-TODO: Add description of the coffee meeting.
+We launched our new monthly coffee meeting format: a short, informal online get-together for network members to chat about their projects, share interesting finds, and catch up.
+
+We intend to continue this on a monthly basis going forward. The next coffee meeting will be on April 2, 2026 at 1 pm CET.

--- a/content/posts/coffee-meeting-2026-04.md
+++ b/content/posts/coffee-meeting-2026-04.md
@@ -1,8 +1,0 @@
----
-title: "Coffee Meeting April 2026"
-date: 2026-04-02T14:00:00+02:00
-description: "Informal monthly coffee meeting"
-type: "post"
----
-
-TODO: Add description of the coffee meeting.

--- a/content/posts/digital-computational-paleography.md
+++ b/content/posts/digital-computational-paleography.md
@@ -5,4 +5,10 @@ description: "Workshop on digital and computational paleography with Peter A. St
 type: "post"
 ---
 
-TODO: Add description of the workshop.
+Peter A. Stokes gave us a workshop on Digital and Computational Paleography. While the title suggests a narrow focus, the workshop covered a broader range of topics, including material manuscript studies and the practice of photographically digitising manuscripts, with a strong focus on machine learning and AI.
+
+A central theme was the question of what digital and computational paleography actually is, and what broad requirements such methods have in common: clear input data, a defined question that expects a defined shape of answer (e.g. image in, transcription out), sample or reference or training data, and a way of measuring the quality of the result.
+
+Much of the discussion revolved around the different things ML can do and how they apply to manuscripts: classification, object detection and labelling, regression (for instance for dating), clustering, and data generation. Concrete applications came up repeatedly, such as layout analysis and detection, Handwritten Text Recognition (tying back to the earlier Transkribus workshop), quire and binding analysis, working with multi-spectral images, coping with insufficient image quality, or subtracting writing from a page to make a palimpsest visible.
+
+A particularly intriguing thread was the use of generative AI to create synthetic manuscript data. This can help fill in missing parts of damaged manuscripts to illustrate plausibilities based on how the proposed text fits into the existing gap, or to generate reference data for training and testing other models.

--- a/content/posts/graph-databases-and-networks.md
+++ b/content/posts/graph-databases-and-networks.md
@@ -5,4 +5,6 @@ description: "Workshop on graph databases and networks with Sven Kraus"
 type: "post"
 ---
 
-TODO: Add description of the workshop.
+In a follow-up to the previous introduction to RDF, Sven gave us an overview of graph databases and networks. We discussed a range of topics around how graph-shaped data can be modelled, queried and used in practice.
+
+Among other things, we talked about how networks and knowledge graphs relate and differ, and what it takes for each to be meaningful in a research context. We also got some hands-on experience with Neo4j and Cypher, and discussed the trade-offs between different graph technologies.

--- a/content/posts/rdf-introduction.md
+++ b/content/posts/rdf-introduction.md
@@ -5,4 +5,4 @@ description: "Workshop on RDF with Balduin Landolt"
 type: "post"
 ---
 
-TODO: Add description of the workshop.
+In this internal training session, Balduin gave us an introduction to RDF. We talked about what graphs are, how RDF represents data as triples, and how these triples form graphs. We also discussed how this ties into linked data and why it holds promise for interoperability. We briefly touched on ontologies and inference, and then looked at some shortcomings of RDF, in particular how it differs from labeled property graphs.

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,18 +1,36 @@
 <footer class="footer">
-    <span>&copy; {{ now.Year }} {{ .Site.Params.Footer}}</span>
-    <span>Visit us at <a target="_blank" href="{{ .Site.Params.Github }}">GitHub</a>.</span>
-    <span>
-        Created with <a target="_blank" href="https://gohugo.io/">Hugo</a> using the
-        <a target="_blank" href="https://github.com/526avijitgupta/gokarna">Gokarna</a> theme.
-    </span>
-    {{ if .IsPage }}
-    <p>
-        <span>
-            {{ $githubUrl := printf "%s/tree/main/content/%s" $.Site.Params.Repo (replace .File.Path "\\" "/") }}
-            <a target="_blank" href="{{ $githubUrl }}">
-                <span data-feather='edit'></span> improve this page here.
-            </a>
-        </span>
-    </p>
+    <!-- Option for user to inject custom html -->
+    {{ if .Site.Params.CustomFooterHTML }}
+    {{ .Site.Params.CustomFooterHTML | safeHTML }}
     {{ end }}
+
+    {{ .Scratch.Set "footerText" "" }}
+
+    {{ if (.Site.Params.Footer) }}
+
+        {{ if and (eq .Kind "page") (.Date) }}
+            {{ .Scratch.Add "footerText" (.Date | time.Format "2006") }}
+        {{ else }}
+            {{ .Scratch.Add "footerText" (time.Now | time.Format "2006") }}
+        {{ end }}
+
+        {{ if and (eq .Kind "page") (.Lastmod) (gt (time.Format "2006" .Lastmod) (time.Format "2006" .Date)) }}
+            {{ .Scratch.Add "footerText" "-" }}
+            {{ .Scratch.Add "footerText" (.Lastmod | time.Format "2006") }}
+        {{ end }}
+
+        {{ .Scratch.Add "footerText" " " }}
+        {{ .Scratch.Add "footerText" .Site.Params.Footer }}
+
+        {{ if and (eq .Kind "page") (.Site.Copyright) }}
+            {{ .Scratch.Add "footerText" " " }}
+            {{ .Scratch.Add "footerText" .Site.Copyright }}
+        {{ end }}
+
+    {{ end }}
+
+    {{ if (gt (.Scratch.Get "footerText" | len) 0) }}
+        <span>&copy; {{ .Scratch.Get "footerText" | markdownify }}</span>
+    {{ end }}
+
 </footer>


### PR DESCRIPTION
## Summary

### Home page
- Rename "Current" section to "Current Activities"

### Footer
- Switch from custom footer override to (nearly) the theme default, removing the "Made with heart using Gokarna" line

### Posts
- Add full minutes to the 2024 and 2025 Annual Board Meetings (structured to match the style of the 2023 post)
- Fill in content for the March 2026 Coffee Meeting post
- Remove the April 2026 Coffee Meeting placeholder post
- Fill in content for three workshop posts:
  - Introduction to RDF
  - Graph Databases and Networks
  - Digital and Computational Paleography
- Tidy whitespace in board meeting posts (convert tabs to spaces, reflow paragraphs)